### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,59 @@
+name: Publish Python Package
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Verify distributions
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docflow-agent
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -72,3 +72,12 @@ CLI 엔트리포인트는 다음과 같습니다.
 - `app-dev`
 - `app-test`
 - `app-docs`
+
+## 배포
+
+PyPI 배포용 GitHub Actions workflow는 `.github/workflows/publish-pypi.yml`에 있습니다.
+
+- 기본 동작은 `push` 시 자동 배포가 아니라 `release published` 또는 수동 실행입니다.
+- release 기반 배포는 `main`을 대상으로 만든 release일 때만 publish 합니다.
+- publish job은 먼저 패키지를 build 하고 `twine check`로 검증한 뒤 PyPI에 업로드합니다.
+- 인증은 GitHub Actions trusted publishing 기준입니다. PyPI 프로젝트에서 GitHub repository와 environment `pypi`를 연결해 두어야 합니다.


### PR DESCRIPTION
## Summary\n- add a GitHub Actions workflow to build and publish the package to PyPI\n- use GitHub Actions trusted publishing instead of publishing on every push\n- document the release flow in the README\n\nCloses #8