### PR TITLE
docs: align architecture with edit intent and RPA flow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,59 @@
+name: Publish Python Package
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Verify distributions
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docflow-agent
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Outbound must NOT call core.
 ## Layers
 
 ### inbound/
+
 Entry points only:
 - FastAPI
 - Streamlit
@@ -48,6 +49,7 @@ Rules:
 ---
 
 ### usecases/
+
 Orchestration layer.
 
 Responsibilities:
@@ -60,6 +62,7 @@ Rules:
 - no business logic
 - no parsing logic
 - no direct DB/ECM logic
+- must not depend on file formats or automation tools
 
 ---
 
@@ -83,7 +86,7 @@ Combine multiple units into business bundles
 Perform analysis (aggregation, matching, etc.)
 
 #### edit/
-Apply modifications to structured data
+Produce structured edit intents (no file or UI logic)
 
 #### rules/
 Business rules (accounting, invoice, settlement, validation)
@@ -91,6 +94,8 @@ Business rules (accounting, invoice, settlement, validation)
 Rules:
 - core must not call outbound
 - core operates on structured data only
+- core must not depend on Excel, files, or UI automation
+- core must not know how edits are applied
 
 ---
 
@@ -106,21 +111,28 @@ Includes:
 - OCR
 - LLM
 - database
+- document automation (Excel, RPA, COM)
 
 Responsibilities:
 - fetch/persist data
 - convert structured data to bytes/files
 - convert external responses to typed structures
 - load sources from ECM, mail, SAP/API, files, or other external systems
-- convert files, bytes, and external responses into typed source or external structures
+- convert files, bytes, and external responses into typed structures
+- apply edit intents to documents
+- execute application-level automation when required (Excel, RPA, COM)
+- manage external application sessions and execution lifecycle
 
 Rules:
 - no business logic
 - no classification
 - no rules
 - must not import core
+- must encapsulate all file libraries and automation tools
 
 ---
+
+## Types
 
 ### types/
 
@@ -131,7 +143,8 @@ Includes:
 - parsed structures
 - units
 - bundles
-- db records when persistence is introduced
+- edit intents
+- db records (when needed)
 - results
 
 Rules:
@@ -140,7 +153,7 @@ Rules:
 - allow multiple explicit types
 - allow nested structures
 - avoid unnecessary abstraction
-- imports between types modules are allowed only when they remain acyclic
+- imports between types modules must remain acyclic
 
 ---
 
@@ -168,16 +181,40 @@ Forbidden:
 - core → core, types
 - outbound → outbound, types
 - types → (no imports from other layers)
-- types → types is allowed only when it does not create circular references
+- types → types only if acyclic
 - shared errors may live in root `errors.py`
-- same-layer imports are allowed only when they remain acyclic
-- circular imports are not allowed in any layer
+- circular imports are not allowed
 
 ---
 
 ## Data Flow
 
-source → parse → unit → category → combine → analyze → rules
+source → parse → unit → category → combine → analyze → rules → edit
+
+---
+
+## Document Editing / Automation
+
+- core must produce structured edit intents only
+- outbound must apply edit intents to documents
+- file libraries (e.g. openpyxl) must stay in outbound
+- automation tools (Excel COM, RPA) must stay in outbound
+- workbook, worksheet, or UI automation objects must not escape outbound
+- usecases must not depend on file or automation implementation details
+
+Execution rules:
+- prefer file-level processing (e.g. openpyxl) by default
+- use application-level automation (Excel, RPA) only when required
+- outbound is responsible for choosing execution strategy
+
+Automation responsibilities (outbound):
+- manage application sessions (start, reuse, terminate)
+- handle file locks and concurrent access
+- handle timeouts and retries
+- handle popups or blocking states
+- ensure document save correctness
+- optionally verify results after write (read-back validation)
+- trigger recalculation when needed
 
 ---
 
@@ -220,17 +257,18 @@ source → parse → unit → category → combine → analyze → rules
 - keep modules small
 - avoid generic names (logic, manager, util)
 - use explicit names
-- keep shared custom errors in root `errors.py` until growth justifies subpackages
+- keep shared custom errors in root `errors.py`
+
+---
 
 ## Error Rules
 
 - shared custom errors may live in root `errors.py`
 - core raises business errors
-- raise integration errors from `outbound`
-- usecases may propagate existing errors and may raise orchestration-specific errors only when the failure is about usecase flow itself
-- do not define custom errors inside `inbound`
-- `inbound` must translate custom errors into HTTP/UI/CLI/agent-friendly outputs
-- if errors grow significantly, split root `errors.py` into subpackages later
+- outbound raises integration errors (file, automation, external systems)
+- usecases may propagate errors or raise orchestration-specific errors
+- inbound translates errors into user-friendly outputs
+- do not define custom errors inside inbound
 
 ---
 
@@ -243,15 +281,19 @@ source → parse → unit → category → combine → analyze → rules
 - parse
 - category
 - combine
+- edit
 - usecases
 
 ### Integration
 - outbound modules
+- file handlers
+- document automation (RPA, Excel)
 
 Rules:
 - must run locally
 - no real external systems
 - use fixtures or monkeypatch
+- automation tests may be optional if environment-dependent
 
 ---
 
@@ -261,9 +303,12 @@ Rules:
 2. parse source
 3. categorize units
 4. combine if needed
-5. apply rules
-6. orchestrate in usecase
-7. test
+5. analyze combined bundles
+6. apply rules
+7. produce edit intents
+8. orchestrate in usecase
+9. apply edits via outbound
+10. test
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,12 @@ CLI 엔트리포인트는 다음과 같습니다.
 - `app-dev`
 - `app-test`
 - `app-docs`
+
+## 배포
+
+PyPI 배포용 GitHub Actions workflow는 `.github/workflows/publish-pypi.yml`에 있습니다.
+
+- 기본 동작은 `push` 시 자동 배포가 아니라 `release published` 또는 수동 실행입니다.
+- release 기반 배포는 `main`을 대상으로 만든 release일 때만 publish 합니다.
+- publish job은 먼저 패키지를 build 하고 `twine check`로 검증한 뒤 PyPI에 업로드합니다.
+- 인증은 GitHub Actions trusted publishing 기준입니다. PyPI 프로젝트에서 GitHub repository와 environment `pypi`를 연결해 두어야 합니다.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ src/docflow_agent/
     edit/
     rules/
   outbound/
+    document_automation.py
   types/
+    edit.py
 ```
 
 현재 구현된 최소 흐름은 Excel source를 읽어 sheet unit으로 파싱하고, invoice category를 식별한 뒤 invoice bundle로 결합하고 accounting rule을 검증하는 흐름입니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docflow-agent
 
-다양한 입력 소스를 Agent와 usecase로 오케스트레이션하고, `source -> unit -> bundle` 모델로 확장할 수 있도록 만든 문서 처리 프레임워크입니다.
+다양한 입력 소스를 Agent와 usecase로 오케스트레이션하고, `source -> unit -> bundle` 모델 위에서 문서 해석, 분석, 규칙 검증, 문서 수정 자동화까지 확장할 수 있도록 만든 문서 처리 프레임워크입니다.
 
 ## 아키텍처
 
@@ -13,10 +13,10 @@ usecases -> outbound
 ```
 
 - `inbound`: FastAPI, Streamlit, LangGraph, CLI 진입점
-- `usecases`: 소스 조회, core 호출, outbound 호출, 결과 조합
-- `core`: source kind 판단, unit 파싱, category 판단, bundle 결합, 분석, 규칙
-- `outbound`: ECM, files, mail, SAP, OCR, LLM, DB 같은 외부 연동
-- `types`: source, unit, bundle, external record, result 같은 실데이터 구조
+- `usecases`: 소스 조회, core 호출, outbound 호출, 결과 조합, 저장/전달 orchestration
+- `core`: source kind 판단, unit 파싱, category 판단, bundle 결합, 분석, 규칙, edit intent 생성
+- `outbound`: ECM, files, mail, SAP, OCR, LLM, DB, Excel automation, RPA, COM 같은 외부 연동과 실행
+- `types`: source, unit, bundle, external record, edit intent, result 같은 실데이터 구조
 
 핵심 개념도 바뀌었습니다.
 
@@ -24,8 +24,9 @@ usecases -> outbound
 - `unit`: 처리 단위. Excel sheet, PDF page group, image set, API record
 - `bundle`: 여러 unit을 비즈니스 목적에 맞게 합친 구조
 - `category`: business meaning. 예: invoice, settlement
+- `edit intent`: core가 결정한 수정 명세. 실제 파일/애플리케이션 수정은 outbound가 수행
 
-core는 구조화된 타입만 다루고 outbound를 전혀 모릅니다. outbound는 외부 응답, 파일, bytes, API 호출을 책임집니다.
+core는 구조화된 타입만 다루고 outbound를 전혀 모릅니다. outbound는 외부 응답, 파일, bytes, API 호출뿐 아니라 문서 수정 실행과 애플리케이션 자동화까지 책임집니다.
 
 ## 프로젝트 구조
 
@@ -46,6 +47,8 @@ src/docflow_agent/
 ```
 
 현재 구현된 최소 흐름은 Excel source를 읽어 sheet unit으로 파싱하고, invoice category를 식별한 뒤 invoice bundle로 결합하고 accounting rule을 검증하는 흐름입니다.
+
+장기적으로는 여기서 끝나지 않고, core가 edit intent를 만들고 outbound가 openpyxl, Excel COM, 또는 RPA로 실제 수정을 실행하는 구조를 목표로 합니다.
 
 ## example
 
@@ -72,6 +75,21 @@ CLI 엔트리포인트는 다음과 같습니다.
 - `app-dev`
 - `app-test`
 - `app-docs`
+
+## 문서 수정과 자동화
+
+문서 수정은 두 단계로 나뉩니다.
+
+- `core/edit`: 무엇을 바꿔야 하는지 결정하고 edit intent를 생성
+- `outbound`: edit intent를 실제 문서나 애플리케이션에 적용
+
+즉, 셀 값을 바꿔야 하는지, 어떤 시트를 추가해야 하는지, 어떤 재계산이 필요한지는 core가 판단하고, 실제 openpyxl 처리나 Excel COM/RPA 실행은 outbound가 맡습니다.
+
+기본 원칙은 다음과 같습니다.
+
+- 기본값은 파일 레벨 처리
+- 애플리케이션 자동화는 파일 레벨 처리로 해결할 수 없을 때만 사용
+- workbook, worksheet, COM 객체, UI automation 객체는 outbound 밖으로 나오지 않음
 
 ## 배포
 

--- a/docs/ecm.md
+++ b/docs/ecm.md
@@ -2,7 +2,7 @@
 
 `src/docflow_agent/outbound/ecm.py`는 특정 벤더 SDK에 묶이지 않는 범용 ECM HTTP 클라이언트를 제공합니다.
 
-ECM은 이 프로젝트에서 source를 가져오거나 결과 파일을 다시 저장하는 outbound 역할을 맡습니다. business category 판단이나 bundle 조합은 여기서 하지 않습니다.
+ECM은 이 프로젝트에서 source를 가져오거나 결과 파일을 다시 저장하는 outbound 역할을 맡습니다. business category 판단, bundle 조합, edit intent 생성은 여기서 하지 않습니다.
 
 ## 제공 기능
 
@@ -13,6 +13,14 @@ ECM은 이 프로젝트에서 source를 가져오거나 결과 파일을 다시 
 - `download_document`: 문서 다운로드 후 로컬 저장
 - `upload_document`: 로컬 파일 업로드
 - `fetch_from_ecm`: 다운로드 기능을 감싼 단순 helper
+
+## 역할 경계
+
+- `core`: 어떤 문서를 찾아야 하는지, 어떤 수정이 필요한지 판단
+- `usecases`: ECM 검색/다운로드/업로드 시점 orchestration
+- `outbound/ecm`: 실제 HTTP 요청, 응답 파싱, 파일 저장/업로드 실행
+
+ECM은 문서 수정의 실행 결과를 다시 저장하는 용도로도 사용할 수 있지만, 수정 규칙 자체를 알면 안 됩니다.
 
 ## 핵심 타입
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -8,7 +8,7 @@
 - `outbound`는 그 변경을 실제 파일이나 애플리케이션에 적용한다
 - `usecases`는 edit intent 생성과 실행 시점을 오케스트레이션한다
 
-즉, core는 `ChangeCell`, `InsertSheet`, `RecalculateWorkbook` 같은 구조화된 edit intent를 만들고, outbound는 이를 openpyxl, Excel COM, 또는 RPA로 실행합니다.
+즉, core는 `CellValueEditIntent`, `InsertSheetEditIntent`, `RecalculateWorkbookEditIntent`, `SaveDocumentEditIntent` 같은 구조화된 edit intent를 만들고, outbound는 이를 openpyxl, Excel COM, 또는 RPA로 실행합니다.
 
 ## 실행 전략
 

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -1,0 +1,40 @@
+# Edit Intent And Automation
+
+이 프로젝트에서 문서 수정은 `core`와 `outbound` 사이의 역할 분리가 가장 중요합니다.
+
+## 기본 원칙
+
+- `core/edit`는 무엇을 바꿔야 하는지 결정한다
+- `outbound`는 그 변경을 실제 파일이나 애플리케이션에 적용한다
+- `usecases`는 edit intent 생성과 실행 시점을 오케스트레이션한다
+
+즉, core는 `ChangeCell`, `InsertSheet`, `RecalculateWorkbook` 같은 구조화된 edit intent를 만들고, outbound는 이를 openpyxl, Excel COM, 또는 RPA로 실행합니다.
+
+## 실행 전략
+
+기본 실행 전략은 다음과 같습니다.
+
+1. 가능하면 파일 레벨 처리부터 시도한다
+2. 파일 레벨 처리로 해결되지 않으면 애플리케이션 자동화를 사용한다
+3. 어떤 전략을 택할지는 outbound가 결정한다
+
+## outbound 책임
+
+- 파일 라이브러리 사용
+- Excel 애플리케이션 세션 시작/재사용/종료
+- COM 또는 RPA 실행
+- 파일 잠금 처리
+- 저장과 재계산 보장
+- 필요 시 read-back 검증
+
+## 금지 사항
+
+- core가 openpyxl, COM, RPA 라이브러리를 import 하면 안 된다
+- usecase가 workbook, worksheet, COM 객체를 다루면 안 된다
+- outbound 밖으로 UI automation object가 나오면 안 된다
+
+## 테스트 전략
+
+- edit intent 생성은 unit test로 검증
+- 파일 수정기는 integration test로 검증
+- RPA/COM 연동 테스트는 환경 의존적일 수 있으므로 optional test로 분리 가능

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # docflow-agent docs
 
-이 문서는 `docflow-agent`의 source/unit/bundle 아키텍처와 outbound 가이드를 정리합니다.
+이 문서는 `docflow-agent`의 source/unit/bundle 아키텍처와 edit-intent 기반 문서 수정, 그리고 outbound 실행 가이드를 정리합니다.
 
 ## 아키텍처
 
@@ -15,16 +15,18 @@ usecases -> outbound
 데이터 흐름은 다음 개념을 사용합니다.
 
 ```text
-source -> parse -> unit -> category -> combine -> analyze -> rules
+source -> parse -> unit -> category -> combine -> analyze -> rules -> edit
 ```
 
 - `source`: 입력 원천
 - `unit`: 처리 단위
 - `bundle`: 분석 전 결합 결과
 - `category`: business meaning
+- `edit`: core가 만든 수정 명세. 실제 적용은 outbound에서 실행
 
 ## 현재 문서
 
 - `model.md`: source, unit, bundle, category 모델 설명
+- `editing.md`: edit intent와 document automation 경계 설명
 - `ecm.md`: 범용 ECM 연동 방식과 `crypto/search/download/upload` 설명
 - `llm.md`: Agent에서 사용하는 LLM outbound 구성과 설정 설명

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -8,6 +8,7 @@
 - 로컬 테스트에서는 stub 모델로 동작
 - 운영 환경에서는 provider 설정만 바꿔 실제 모델로 연결
 - usecase가 필요할 때만 호출되고 core는 LLM에 의존하지 않음
+- 문서 해석 보조는 가능하지만 business rule의 source of truth가 되지 않음
 
 ## 제공 기능
 
@@ -22,9 +23,17 @@
 - `DOCFLOW_AGENT_LLM_PROVIDER`: `stub` 또는 `openai`
 - `DOCFLOW_AGENT_LLM_MODEL`: 모델 이름
 - `DOCFLOW_AGENT_LLM_TEMPERATURE`: temperature
-- `DOCFLOW_AGENT_LLM_API_KEY`: provider API key
+- `DOCFLOW_AGENT_LLM_API_KEY`: provider API key (`openai`일 때만 필요)
 
-기본값은 `stub`이며, 외부 서비스 없이도 로컬에서 실행됩니다.
+기본값은 `stub`이며, 외부 서비스 없이도 로컬에서 실행됩니다. `DOCFLOW_AGENT_LLM_PROVIDER=openai`를 사용할 때만 API key가 필요합니다.
+
+## 역할 경계
+
+- `core`: category, analyze, rules 같은 결정 로직
+- `usecases`: LLM 호출 여부 결정
+- `outbound/llm`: 실제 provider 연결과 메시지 호출
+
+LLM은 보조 해석이나 설명에 사용할 수 있지만, 회계 규칙이나 확정 판정 로직은 여전히 core에 있어야 합니다.
 
 ## 사용 예시
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -8,16 +8,25 @@
 - `unit`: source를 파싱한 뒤 얻는 처리 단위
 - `category`: unit 또는 bundle의 business meaning
 - `bundle`: 여러 unit을 비즈니스 목적에 맞게 합친 구조
+- `edit intent`: 수정이 필요할 때 core가 만드는 구조화된 변경 명세
 
 ## 예시
 
 - Excel source -> sheet unit -> invoice category -> `InvoiceBundle`
 - PDF source -> page group unit -> settlement category -> `SettlementBundle`
 - SAP/API source -> record unit -> reconciliation category -> matching bundle
+- Invoice bundle -> edit intent -> outbound execution
 
 ## 설계 원칙
 
 - usecase가 core와 outbound를 오케스트레이션한다
 - core는 구조화된 타입만 다룬다
-- outbound는 파일, bytes, 외부 API, DB 응답을 다룬다
+- outbound는 파일, bytes, 외부 API, DB 응답, 문서 수정 실행을 다룬다
 - 타입은 추상 base model이 아니라 실제 데이터 구조를 반영한다
+
+## editing 원칙
+
+- core는 수정 실행이 아니라 수정 의도를 표현한다
+- usecase는 edit intent 생성과 실행 시점을 오케스트레이션한다
+- outbound는 파일 처리 또는 애플리케이션 자동화로 edit intent를 적용한다
+- Excel workbook, worksheet, COM object, UI automation object는 outbound 밖으로 노출하지 않는다

--- a/src/docflow_agent/core/edit/__init__.py
+++ b/src/docflow_agent/core/edit/__init__.py
@@ -1,0 +1,1 @@
+"""Edit intent generation."""

--- a/src/docflow_agent/core/edit/invoice.py
+++ b/src/docflow_agent/core/edit/invoice.py
@@ -1,0 +1,15 @@
+from docflow_agent.types.bundle import InvoiceBundle
+from docflow_agent.types.edit import CellValueEditIntent
+
+
+def build_invoice_edit_intents(bundle: InvoiceBundle) -> list[CellValueEditIntent]:
+    if bundle.invoice_number is None:
+        return []
+
+    return [
+        CellValueEditIntent(
+            sheet_name="Summary",
+            cell_ref="B2",
+            value=bundle.invoice_number,
+        )
+    ]

--- a/src/docflow_agent/outbound/document_automation.py
+++ b/src/docflow_agent/outbound/document_automation.py
@@ -1,0 +1,14 @@
+from docflow_agent.types.edit import CellValueEditIntent, EditExecutionResult
+from docflow_agent.types.source import SpreadsheetSource
+
+
+def apply_spreadsheet_edit_intents(
+    source: SpreadsheetSource,
+    edit_intents: list[CellValueEditIntent],
+) -> EditExecutionResult:
+    # Stub execution for local testing. Real file or application automation stays here.
+    _ = source
+    return EditExecutionResult(
+        applied_count=len(edit_intents),
+        strategy="file_stub",
+    )

--- a/src/docflow_agent/outbound/document_automation.py
+++ b/src/docflow_agent/outbound/document_automation.py
@@ -1,14 +1,39 @@
-from docflow_agent.types.edit import CellValueEditIntent, EditExecutionResult
+from docflow_agent.types.edit import (
+    CellValueEditIntent,
+    EditExecutionResult,
+    InsertSheetEditIntent,
+    RecalculateWorkbookEditIntent,
+    SaveDocumentEditIntent,
+)
 from docflow_agent.types.source import SpreadsheetSource
 
 
 def apply_spreadsheet_edit_intents(
     source: SpreadsheetSource,
-    edit_intents: list[CellValueEditIntent],
+    edit_intents: list[
+        CellValueEditIntent
+        | InsertSheetEditIntent
+        | RecalculateWorkbookEditIntent
+        | SaveDocumentEditIntent
+    ],
 ) -> EditExecutionResult:
-    # Stub execution for local testing. Real file or application automation stays here.
+    # Stub executor for local testing. Real file-level and app-level automation stays here.
     _ = source
+    strategy = _choose_execution_strategy(edit_intents)
     return EditExecutionResult(
         applied_count=len(edit_intents),
-        strategy="file_stub",
+        strategy=strategy,
     )
+
+
+def _choose_execution_strategy(
+    edit_intents: list[
+        CellValueEditIntent
+        | InsertSheetEditIntent
+        | RecalculateWorkbookEditIntent
+        | SaveDocumentEditIntent
+    ],
+) -> str:
+    if any(isinstance(intent, RecalculateWorkbookEditIntent) for intent in edit_intents):
+        return "application_stub"
+    return "file_stub"

--- a/src/docflow_agent/types/edit.py
+++ b/src/docflow_agent/types/edit.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CellValueEditIntent:
+    sheet_name: str
+    cell_ref: str
+    value: str
+
+
+@dataclass(frozen=True)
+class EditExecutionResult:
+    applied_count: int
+    strategy: str

--- a/src/docflow_agent/types/edit.py
+++ b/src/docflow_agent/types/edit.py
@@ -9,6 +9,22 @@ class CellValueEditIntent:
 
 
 @dataclass(frozen=True)
+class InsertSheetEditIntent:
+    sheet_name: str
+    position_index: int | None = None
+
+
+@dataclass(frozen=True)
+class RecalculateWorkbookEditIntent:
+    full_rebuild: bool = False
+
+
+@dataclass(frozen=True)
+class SaveDocumentEditIntent:
+    target_location: str | None = None
+
+
+@dataclass(frozen=True)
 class EditExecutionResult:
     applied_count: int
     strategy: str

--- a/src/docflow_agent/usecases/process_source.py
+++ b/src/docflow_agent/usecases/process_source.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from docflow_agent.core.analyze.invoice import analyze_invoice_bundle
 from docflow_agent.core.category.invoice import categorize_excel_units
 from docflow_agent.core.combine.invoice import combine_invoice_units
+from docflow_agent.core.edit.invoice import build_invoice_edit_intents
 from docflow_agent.core.parse.excel import parse_excel_units
 from docflow_agent.core.rules.accounting import validate_accounting_rule
 from docflow_agent.core.rules.invoice import apply_invoice_rule
@@ -29,6 +30,7 @@ def process_source(source_ref: SourceRef) -> ProcessResult:
     bundle = combine_invoice_units(source=source, units=units, category=category)
     bundle = apply_invoice_rule(bundle)
     analysis = analyze_invoice_bundle(bundle)
+    edit_intents = build_invoice_edit_intents(bundle)
     validation_errors = validate_accounting_rule(bundle)
 
     return ProcessResult(
@@ -39,6 +41,7 @@ def process_source(source_ref: SourceRef) -> ProcessResult:
         bundle_data={
             "bundle": asdict(bundle),
             "analysis": analysis,
+            "edit_intents": [asdict(intent) for intent in edit_intents],
         },
         messages=validation_errors or ["Source processed successfully."],
     )

--- a/tests/test_document_automation.py
+++ b/tests/test_document_automation.py
@@ -1,0 +1,52 @@
+from docflow_agent.outbound.document_automation import apply_spreadsheet_edit_intents
+from docflow_agent.types.edit import (
+    CellValueEditIntent,
+    InsertSheetEditIntent,
+    RecalculateWorkbookEditIntent,
+    SaveDocumentEditIntent,
+)
+from docflow_agent.types.source import SourceRef, SpreadsheetSource
+
+
+def test_apply_spreadsheet_edit_intents_uses_file_strategy_by_default() -> None:
+    source = SpreadsheetSource(
+        source_ref=SourceRef(
+            name="invoice.xlsx",
+            location="stub://invoice.xlsx",
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            source_system="ecm",
+        ),
+        sheet_names=["Invoice", "Summary"],
+    )
+
+    result = apply_spreadsheet_edit_intents(
+        source=source,
+        edit_intents=[
+            CellValueEditIntent(sheet_name="Summary", cell_ref="B2", value="INV-001"),
+            InsertSheetEditIntent(sheet_name="Audit"),
+            SaveDocumentEditIntent(),
+        ],
+    )
+
+    assert result.applied_count == 3
+    assert result.strategy == "file_stub"
+
+
+def test_apply_spreadsheet_edit_intents_uses_application_strategy_when_recalc_is_needed() -> None:
+    source = SpreadsheetSource(
+        source_ref=SourceRef(
+            name="invoice.xlsx",
+            location="stub://invoice.xlsx",
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            source_system="ecm",
+        ),
+        sheet_names=["Invoice", "Summary"],
+    )
+
+    result = apply_spreadsheet_edit_intents(
+        source=source,
+        edit_intents=[RecalculateWorkbookEditIntent(full_rebuild=True)],
+    )
+
+    assert result.applied_count == 1
+    assert result.strategy == "application_stub"

--- a/tests/test_edit_invoice.py
+++ b/tests/test_edit_invoice.py
@@ -1,0 +1,22 @@
+from docflow_agent.core.edit.invoice import build_invoice_edit_intents
+from docflow_agent.types.bundle import InvoiceBundle
+from docflow_agent.types.unit import ExcelSheetUnit
+
+
+def test_build_invoice_edit_intents_returns_summary_update() -> None:
+    bundle = InvoiceBundle(
+        category="invoice",
+        source_name="invoice.xlsx",
+        units=[
+            ExcelSheetUnit(sheet_name="Invoice", row_count=10),
+            ExcelSheetUnit(sheet_name="Summary", row_count=5),
+        ],
+        invoice_number="INV-001",
+    )
+
+    edit_intents = build_invoice_edit_intents(bundle)
+
+    assert len(edit_intents) == 1
+    assert edit_intents[0].sheet_name == "Summary"
+    assert edit_intents[0].cell_ref == "B2"
+    assert edit_intents[0].value == "INV-001"

--- a/tests/test_process_source.py
+++ b/tests/test_process_source.py
@@ -23,8 +23,10 @@ def test_process_source_orchestrates_excel_invoice_flow() -> None:
     assert result.unit_count == 3
     bundle = cast(dict[str, object], result.bundle_data["bundle"])
     analysis = cast(dict[str, object], result.bundle_data["analysis"])
+    edit_intents = cast(list[dict[str, object]], result.bundle_data["edit_intents"])
     assert bundle["invoice_number"] == "INV-001"
     assert analysis["unit_names"] == ["Invoice", "LineItems", "Summary"]
+    assert edit_intents == [{"sheet_name": "Summary", "cell_ref": "B2", "value": "INV-001"}]
     assert result.messages == ["Source processed successfully."]
 
 


### PR DESCRIPTION
## Summary
- align AGENTS, README, and docs with the edit-intent and RPA-ready architecture
- clarify that core produces edit intents and outbound executes file or application automation
- add a dedicated editing guide for document automation boundaries
 
Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Document modification automation capabilities now available, enabling applications to apply structured edits to spreadsheets with built-in execution strategies.
  * Automated publishing workflow configured for package releases.

* **Documentation**
  * Comprehensive documentation expanded to cover document editing architecture, including role boundaries, automation strategies, and execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->